### PR TITLE
build: add public directory for vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.csv
+public/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha",
     "start": "node script.js",
     "dev": "live-server /storage/emulated/0/Documents/project-start",
-    "build": "echo 'No build step yet — just copying files manually.'",
+    "build": "rm -rf public && mkdir public && cp -r *.html *.css *.js *.png public/",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "simulate": "node simulate.js",
     "simulate:aggressive": "node simulate.js aggressive",


### PR DESCRIPTION
## Summary
- create build script that populates a `public` folder for static deployment
- ignore generated `public` output in git

## Testing
- `npm run build`
- `npm test` *(fails: "No test files found: \"test\"")*

------
https://chatgpt.com/codex/tasks/task_e_6894eba8bfb08326aba51174091e6fcf