### PR TITLE
Add missing utility and UI modules to enable game initialization

### DIFF
--- a/ui/overlay.js
+++ b/ui/overlay.js
@@ -1,0 +1,7 @@
+export function createOverlay(id, content = '') {
+  const overlay = document.createElement('div');
+  overlay.id = id;
+  overlay.innerHTML = content;
+  document.body.appendChild(overlay);
+  return overlay;
+}

--- a/ui/restartOverlay.js
+++ b/ui/restartOverlay.js
@@ -1,0 +1,5 @@
+import { createOverlay } from './overlay.js';
+
+export function showRestartScreen(message = 'Game Over') {
+  return createOverlay('restart-overlay', message);
+}

--- a/utils/animation.js
+++ b/utils/animation.js
@@ -1,0 +1,15 @@
+export function runAnimation(element, animationClass) {
+  return new Promise((resolve) => {
+    if (!element) {
+      resolve();
+      return;
+    }
+    element.classList.add(animationClass);
+    function handleEnd() {
+      element.classList.remove(animationClass);
+      element.removeEventListener('animationend', handleEnd);
+      resolve();
+    }
+    element.addEventListener('animationend', handleEnd, { once: true });
+  });
+}

--- a/utils/numberFormat.js
+++ b/utils/numberFormat.js
@@ -1,0 +1,3 @@
+export function formatNumber(num) {
+  return Number.isFinite(num) ? num.toLocaleString() : String(num);
+}

--- a/utils/rateTracker.js
+++ b/utils/rateTracker.js
@@ -1,0 +1,22 @@
+export default class RateTracker {
+  constructor() {
+    this.lastTime = performance.now();
+    this.count = 0;
+    this.rate = 0;
+  }
+
+  mark(count = 1) {
+    const now = performance.now();
+    this.count += count;
+    const elapsed = now - this.lastTime;
+    if (elapsed >= 1000) {
+      this.rate = this.count / (elapsed / 1000);
+      this.count = 0;
+      this.lastTime = now;
+    }
+  }
+
+  getRate() {
+    return this.rate;
+  }
+}

--- a/utils/stamina.js
+++ b/utils/stamina.js
@@ -1,0 +1,7 @@
+export function calculateMaxStamina(base = 100, endurance = 0) {
+  return base + endurance * 10;
+}
+
+export function calculateStaminaRegen(base = 1, dexterity = 0) {
+  return base + dexterity * 0.1;
+}

--- a/utils/xp.js
+++ b/utils/xp.js
@@ -1,0 +1,5 @@
+export const XP_EFFICIENCY = 1;
+
+export function calculateKillXp(level = 1, multiplier = 1) {
+  return level * multiplier * XP_EFFICIENCY;
+}


### PR DESCRIPTION
## Summary
- Add lightweight utility modules (rate tracking, number formatting, animation, XP, stamina) referenced by the main game script
- Provide basic overlay and restart screen helpers to satisfy UI imports

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894ed0b5d3c8326ac473710ddb555fb