### PR TITLE
docs: expand upgrade explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ Base Card HP        +3 per level   ?       100 * level^2   Enhance base HP for a
 Card HP per Kill        1       ?       150 * level^2	HP recovered by cards after each kill
 
 
+### Card Upgrade Mechanics
+
+Clearing encounters can present a selection of upgrade cards. Each upgrade
+applies immediately and can be purchased multiple times to stack its level.
+
+- **Cost formula:** `100 * stage * world` multiplied by a rarity modifier.
+  Rarity multipliers are 1× for common, 1.5× for uncommon, 2× for rare,
+  and 3× for super‑rare upgrades.
+- If none of the options are affordable, one upgrade is offered for free.
+- **Prestige upgrades** appear only after resetting and focus on mana and other
+  long‑term bonuses.
+
+Examples include healing when cards are redrawn, extra card slots, and damage
+or HP multipliers. For a deeper explanation, see
+[docs/UPGRADES.md](docs/UPGRADES.md).
+
 🃏 Card Progression
 
 Stat	Scaling Formula	Notes

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -1,0 +1,23 @@
+# Upgrade System
+
+The game features multiple upgrade paths to strengthen your deck.
+
+## Global Upgrades
+Global upgrades are unlocked as you progress and apply to every run. Each upgrade
+has a level-based cost formula and can be increased repeatedly. Examples include
+additional card slots, global damage multipliers, faster auto-attacks, and bonus
+health per level.
+
+## Card Upgrades
+After clearing a stage, an overlay presents a random selection of upgrade cards.
+Purchasing an upgrade immediately applies its effect and increases its level.
+
+- **Base cost:** `100 * stage * world`
+- **Rarity multipliers:** common ×1, uncommon ×1.5, rare ×2, super-rare ×3
+- **Weighted rolls:** common upgrades appear more frequently than rare ones.
+- One option becomes free if none are affordable.
+- Prestige-only upgrades offer mana-focused bonuses and unlock after resetting.
+
+Common examples are Heal on Redraw, HP per Kill, Extra Card Slot, and damage or HP multipliers.
+
+Upgrade definitions and cost calculations live in `cardUpgrades.js`.


### PR DESCRIPTION
## Summary
- document card upgrade mechanics including cost formula, rarity multipliers, and prestige upgrades
- add detailed upgrade system reference in docs/UPGRADES.md

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f13f576c8326959ac978212fd432