### PR TITLE
Add missing utility and UI modules to enable game initialization

### DIFF
--- a/ui/overlay.js
+++ b/ui/overlay.js
@@ -1,0 +1,7 @@
+export function createOverlay(id, content = '') {
+  const overlay = document.createElement('div');
+  overlay.id = id;
+  overlay.innerHTML = content;
+  document.body.appendChild(overlay);
+  return overlay;
+}

--- a/ui/restartOverlay.js
+++ b/ui/restartOverlay.js
@@ -1,0 +1,5 @@
+import { createOverlay } from './overlay.js';
+
+export function showRestartScreen(message = 'Game Over') {
+  return createOverlay('restart-overlay', message);
+}

--- a/utils/animation.js
+++ b/utils/animation.js
@@ -1,0 +1,15 @@
+export function runAnimation(element, animationClass) {
+  return new Promise((resolve) => {
+    if (!element) {
+      resolve();
+      return;
+    }
+    element.classList.add(animationClass);
+    function handleEnd() {
+      element.classList.remove(animationClass);
+      element.removeEventListener('animationend', handleEnd);
+      resolve();
+    }
+    element.addEventListener('animationend', handleEnd, { once: true });
+  });
+}

--- a/utils/numberFormat.js
+++ b/utils/numberFormat.js
@@ -1,0 +1,3 @@
+export function formatNumber(num) {
+  return Number.isFinite(num) ? num.toLocaleString() : String(num);
+}

--- a/utils/rateTracker.js
+++ b/utils/rateTracker.js
@@ -1,0 +1,33 @@
+export default class RateTracker {
+  constructor(windowMs = 1000) {
+    this.windowMs = windowMs;
+    this.lastTime = performance.now();
+    this.lastValue = 0;
+    this.rate = 0;
+  }
+
+  record(value) {
+    const now = performance.now();
+    const elapsed = now - this.lastTime;
+    if (elapsed > 0) {
+      this.rate = (value - this.lastValue) / (elapsed / 1000);
+    }
+    this.lastValue = value;
+    this.lastTime = now;
+  }
+
+  reset(value = 0) {
+    this.lastValue = value;
+    this.rate = 0;
+    this.lastTime = performance.now();
+  }
+
+  // legacy method used by some modules
+  mark(count = 1) {
+    this.record(this.lastValue + count);
+  }
+
+  getRate() {
+    return this.rate;
+  }
+}

--- a/utils/stamina.js
+++ b/utils/stamina.js
@@ -1,0 +1,7 @@
+export function calculateMaxStamina(base = 100, endurance = 0) {
+  return base + endurance * 10;
+}
+
+export function calculateStaminaRegen(base = 1, dexterity = 0) {
+  return base + dexterity * 0.1;
+}

--- a/utils/xp.js
+++ b/utils/xp.js
@@ -1,0 +1,17 @@
+export const XP_EFFICIENCY = 1;
+
+// Compute XP needed for a card to reach the next level.
+// Scales with the card's face value and current level.
+export function xpRequirement(value = 1, level = 1) {
+  const valueFactor = 1 + (value - 1) / 12;
+  return Math.round(10 * level * valueFactor);
+}
+
+// Estimate an enemy's effective level based on stage and world.
+export function effectiveLevel(stage = 1, world = 1) {
+  return stage + (world - 1) * 10;
+}
+
+export function calculateKillXp(level = 1, multiplier = 1) {
+  return level * multiplier * XP_EFFICIENCY;
+}


### PR DESCRIPTION
## Summary
- Add lightweight utility modules (rate tracking, number formatting, animation, XP, stamina) referenced by the main game script
- Provide basic overlay and restart screen helpers to satisfy UI imports
- Implement XP helpers for card leveling and enemy scaling to fix remaining import errors
- Extend RateTracker with record/reset methods so rate calculations don't break startup

## Testing
- `npm test` *(fails: No test files found: "test")*
- `npm run lint` *(fails: "lucide" is not defined; "PIXI" is not defined; parsing error in style.css; 354 errors total)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed0b5d3c8326ac473710ddb555fb